### PR TITLE
Add custom_name config for filename

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ Here is a brief description of the optional config keys
 
 `destination_path` - Specifies where to write the resulting `.jsonl` file to. By default, the file gets written in your working directory.
 
+`custom_name` - Specifies a custom name for the filename, instead of the stream name (i.e. `{custom_name}-{timestamp}.jsonl`, asumming `do_timestamp_file` is `true`). By default, the stream name will be used.
+
 `do_timestamp_file` - specifies if the file should get timestamped. By default, the resulting file will have a timestamp in the file name (i.e. `exchange_rate-{timestamp}.jsonl` as described above in the `Run` section). If this option gets set to `false`, the resulting file will not have a timestamp associated with it (i.e. `exchange_rate.jsonl` in our example).
 
 ---

--- a/config.sample.json
+++ b/config.sample.json
@@ -1,4 +1,5 @@
 {
     "destination_path": "",
+    "custom_name": "",
     "do_timestamp_file": true
 }

--- a/target_jsonl.py
+++ b/target_jsonl.py
@@ -34,7 +34,12 @@ def float_to_decimal(value):
     return value
 
 
-def persist_messages(messages, destination_path, do_timestamp_file=True):
+def persist_messages(
+    messages,
+    destination_path,
+    custom_name=None,
+    do_timestamp_file=True
+):
     state = None
     schemas = {}
     key_properties = {}
@@ -58,7 +63,7 @@ def persist_messages(messages, destination_path, do_timestamp_file=True):
 
             validators[o['stream']].validate(float_to_decimal(o['record']))
 
-            filename = o['stream'] + timestamp_file_part + '.jsonl'
+            filename = (custom_name or o['stream']) + timestamp_file_part + '.jsonl'
             filename = os.path.expanduser(os.path.join(destination_path, filename))
 
             with open(filename, 'a', encoding='utf-8') as json_file:
@@ -91,7 +96,12 @@ def main():
         config = {}
 
     input_messages = io.TextIOWrapper(sys.stdin.buffer, encoding='utf-8')
-    state = persist_messages(input_messages, config.get('destination_path', ''), config.get('do_timestamp_file', True))
+    state = persist_messages(
+        input_messages,
+        config.get('destination_path', ''),
+        config.get('custom_name', ''),
+        config.get('do_timestamp_file', True)
+    )
 
     emit_state(state)
     logger.debug("Exiting normally")


### PR DESCRIPTION
# Description of change
This PR adds an optional option `custom_name` to specify a custom name instead of the stream name in the resulting filename.  
E.g: Stream name is `entities` and timestamp is `20210218T000000`
1. `custom_name=""` and `do_timestamp_file=true`
```json
{
    "destination_path": "/tmp",
    "custom_name": "",
    "do_timestamp_file": true
}
```
Results in: `/tmp/entities-20210218T000000.jsonl`

2. `custom_name="entity"` and `do_timestamp_file=true`
```json
{
    "destination_path": "/tmp",
    "custom_name": "entity",
    "do_timestamp_file": true
}
```
Results in: `/tmp/entity-20210218T000000.jsonl` 

3.  `custom_name="entity"` and `do_timestamp_file=false`
```json
{
    "destination_path": "/tmp",
    "custom_name": "entity",
    "do_timestamp_file": false
}
```
Results in: `/tmp/entity.jsonl`

3.  `custom_name=""` and `do_timestamp_file=false`
```json
{
    "destination_path": "/tmp",
    "custom_name": "",
    "do_timestamp_file": false
}
```
Results in: `/tmp/entities.jsonl`

# Manual QA steps
 - All combinations of `destination_path`, `custom_name` and `do_timestamp_file tested and worked as expected
 
# Risks
 - None; this is an optional configuration, new implementations will not break
 
# Rollback steps
 - Revert this branch
