### PR TITLE
feat: add adjustment to decimal precision and update singer-python

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     keywords=["singer", "singer.io", "target", "etl"],
     classifiers=['Programming Language :: Python :: 3 :: Only'],
     py_modules=['target_jsonl'],
-    install_requires=['jsonschema==2.6.0', 'singer-python==2.1.4'],
+    install_requires=['jsonschema==2.6.0', 'singer-python==5.8.0', 'adjust-precision-for-schema==0.3.3'],
     entry_points='''
           [console_scripts]
           target-jsonl=target_jsonl:main


### PR DESCRIPTION
# Description of change
@andyh1203 
* Large precision ranges such as from MongoDB are larger than the default decimal precision of 28. One of the postgres targets solves this by dynamically updating the decimal precision based on the schemas. I extracted that and put it into a standalone library for reuse here and elsewhere. Added a reference to https://pypi.org/project/adjust-precision-for-schema/
* singer-python now converts floats to decimals, so `float_to_decimal` is no longer necessary
* decimal.Decimal is not json serializable. `simplejson` is a drop-in replacement for the native json library that elegantly handles serializing Decimals 

