### PR TITLE
Stream name to validation failure

### DIFF
--- a/target_jsonl.py
+++ b/target_jsonl.py
@@ -2,6 +2,7 @@
 
 import argparse
 import io
+import jsonschema
 import simplejson as json
 import os
 import sys
@@ -51,7 +52,11 @@ def persist_messages(
                     "was encountered before a corresponding schema".format(o['stream'])
                 )
 
-            validators[o['stream']].validate((o['record']))
+            try: 
+                validators[o['stream']].validate((o['record']))
+            except jsonschema.ValidationError as e:
+                logger.error(f"Failed parsing the json schema for stream: {o['stream']}.")
+                raise e
 
             filename = (custom_name or o['stream']) + timestamp_file_part + '.jsonl'
             if destination_path:


### PR DESCRIPTION
Closes #8 

# Description of change
```
ERROR Failed parsing the json schema for stream: users.
Traceback (most recent call last):
  File "/home/visch/git/target-jsonl/.venv/bin/target-jsonl", line 33, in <module>
    sys.exit(load_entry_point('target-jsonl==0.1.4', 'console_scripts', 'target-jsonl')())
  File "/home/visch/git/target-jsonl/.venv/lib/python3.8/site-packages/target_jsonl.py", line 97, in main
    state = persist_messages(
  File "/home/visch/git/target-jsonl/.venv/lib/python3.8/site-packages/target_jsonl.py", line 59, in persist_messages
    raise e
  File "/home/visch/git/target-jsonl/.venv/lib/python3.8/site-packages/target_jsonl.py", line 56, in persist_messages
    validators[o['stream']].validate((o['record']))
 ```

# Manual QA steps

Ran with a Failure I was having
 
# Risks
 Try catch adds some compute (laughable) 
 
# Rollback steps
 - revert this branch
