### PR TITLE
relax dependency version constraint

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     keywords=["singer", "singer.io", "target", "etl"],
     classifiers=['Programming Language :: Python :: 3 :: Only'],
     py_modules=['target_jsonl'],
-    install_requires=['jsonschema==2.6.0', 'singer-python==5.8.0', 'adjust-precision-for-schema==0.3.3'],
+    install_requires=['jsonschema==2.6.0', 'singer-python>=5.8.0,<6.0.0', 'adjust-precision-for-schema>=0.3.3,0.4.0'],
     entry_points='''
           [console_scripts]
           target-jsonl=target_jsonl:main


### PR DESCRIPTION
# Description of change
resolves https://github.com/andyhuynh3/target-jsonl/issues/13

relaxes version constraint on dependencies. only top level functions from these dependencies are used, and their api is expected to remain stable in this major version

# Manual QA steps
 - tested & found working with the current versions of singer-python (5.13.0) and adjust-precision-for-schema (0.3.4)
 
# Risks
 - the author for either of these projects removes or changes the interface for functions `singer.get_logger()`, `singer.parse_message()` and `adjust_precision_for_schema.adjust_decimal_precision_for_schema()`
 
# Rollback steps
 - revert this branch